### PR TITLE
Fix/array sizing

### DIFF
--- a/src/main/java/com/piedpiper/swerve/semantic/ArrayChecks.java
+++ b/src/main/java/com/piedpiper/swerve/semantic/ArrayChecks.java
@@ -4,7 +4,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.piedpiper.swerve.error.ArrayBoundsError;
+import com.piedpiper.swerve.lexer.TokenType;
+import com.piedpiper.swerve.lexer.VariableToken;
 import com.piedpiper.swerve.parser.AbstractSyntaxTree;
 
 public class ArrayChecks {
@@ -12,7 +13,7 @@ public class ArrayChecks {
         return arrayNode.getLabel().equals("ARRAY-LIT");
     }
 
-    public static int getMaxDepth(AbstractSyntaxTree arrayNode) {
+    private static int getMaxDepth(AbstractSyntaxTree arrayNode) {
         return getMaxDepth(arrayNode, 1);
     }
 
@@ -26,7 +27,7 @@ public class ArrayChecks {
         return max_depth;
     }
 
-    public static List<List<Integer>> getAllArraySizes(AbstractSyntaxTree arrayNode) {
+    private static List<List<Integer>> getAllArraySizes(AbstractSyntaxTree arrayNode) {
         return getAllArraySizes(arrayNode, new ArrayList<>(), 0);
     }
 
@@ -59,7 +60,7 @@ public class ArrayChecks {
      * @param array
      * @return list of array sizes
      */
-    public static List<Integer> estimateArraySizes(AbstractSyntaxTree array) {
+    private static List<Integer> getAllMaxDepths(AbstractSyntaxTree array) {
         List<List<Integer>> arraySizes = getAllArraySizes(array);
         if (arraySizes.size() == 1)
             return arraySizes.get(0);
@@ -70,13 +71,12 @@ public class ArrayChecks {
         return maxes;
     }
 
-    public static void checkArraySizeMatchesExpectation(AbstractSyntaxTree array, List<Integer> expectedSizes) {
-        List<Integer> actualSizes = estimateArraySizes(array);
-        if (actualSizes.size() > expectedSizes.size()) // less than or equal to is valid
-            throw new ArrayBoundsError("Array value does not match declaration type");
-        for (int i = 0; i < actualSizes.size(); i++) {
-            if (actualSizes.get(i) > expectedSizes.get(i))
-                throw new ArrayBoundsError("Array value size exceeds declared size");
+    public static List<AbstractSyntaxTree> estimateArraySizes(AbstractSyntaxTree array) {
+        List<AbstractSyntaxTree> sizes = new ArrayList<>();
+        List<Integer> depths = getAllMaxDepths(array);
+        for (Integer depth : depths) {
+            sizes.add(new AbstractSyntaxTree(new VariableToken(TokenType.NUMBER, String.valueOf(depth))));
         }
+        return sizes;
     }
 }

--- a/src/main/java/com/piedpiper/swerve/semantic/SemanticAnalyzer.java
+++ b/src/main/java/com/piedpiper/swerve/semantic/SemanticAnalyzer.java
@@ -378,7 +378,7 @@ public class SemanticAnalyzer {
         AbstractSyntaxTree current = sizeNode;
         while (current.hasChildren()) {
             if (!evaluateType(sizeNode.getChildren().get(0)).isType(NodeType.INT))
-                throw new IllegalStatementError("Array index must be type integer but was type " + evaluateType(sizeNode), current.getLineNumber());
+                throw new IllegalStatementError("Array size must be type int but was type " + evaluateType(sizeNode.getChildren().get(0)), current.getLineNumber());
             sizes.add(current.getChildren().get(0));
             if (current.getChildren().size() == 2) // first node will be index value, second will be an ARRAY-INDEX node with children
                 current = current.getChildren().get(1);

--- a/src/main/java/com/piedpiper/swerve/symboltable/Symbol.java
+++ b/src/main/java/com/piedpiper/swerve/symboltable/Symbol.java
@@ -1,5 +1,6 @@
 package com.piedpiper.swerve.symboltable;
 
+import com.piedpiper.swerve.lexer.VariableToken;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class Symbol {
     @NonNull
     private Integer scope;
     private boolean isConstant = false;
-    private List<Integer> arraySizes = List.of(0);
+    private List<AbstractSyntaxTree> arraySizes = List.of(new AbstractSyntaxTree(new VariableToken(TokenType.NUMBER, "0")));
     private AbstractSyntaxTree valueNodes = null;
 
     // use this to add builtin variables
@@ -42,7 +43,7 @@ public class Symbol {
     }
 
     // Array declaration?
-    public Symbol(AbstractSyntaxTree arrayDeclaration, List<Integer> arraySizes, @NonNull EntityType type, Integer valueIndex, @NonNull Integer scope) {
+    public Symbol(AbstractSyntaxTree arrayDeclaration, List<AbstractSyntaxTree> arraySizes, @NonNull EntityType type, Integer valueIndex, @NonNull Integer scope) {
         this.scope = scope;
         this.arraySizes = arraySizes;
         this.type = type;

--- a/src/test/java/com/piedpiper/swerve/semantic/TestArrayChecks.java
+++ b/src/test/java/com/piedpiper/swerve/semantic/TestArrayChecks.java
@@ -1,22 +1,17 @@
 package com.piedpiper.swerve.semantic;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.piedpiper.swerve.error.ArrayBoundsError;
 import com.piedpiper.swerve.lexer.TokenType;
 import com.piedpiper.swerve.lexer.VariableToken;
 import com.piedpiper.swerve.parser.AbstractSyntaxTree;
-import com.piedpiper.swerve.semantic.ArrayChecks;
 
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestArrayChecks {
     private static final AbstractSyntaxTree[] asts = {
@@ -78,127 +73,33 @@ public class TestArrayChecks {
         ))
     };
 
-    private static Stream<Arguments> getMaxDepthProvider() {
-        return Stream.of(
-            // {}
-            Arguments.of(asts[0], 1),
-            // {5, 10}
-            Arguments.of(asts[1], 1),
-            // {{5, 10}}
-            Arguments.of(asts[2], 2),
-            // {{{2, 3}, {4}, {}}, {}, {{1}, {2, 3, 4}}}
-            Arguments.of(asts[3], 3),
-            // {{}, {{}, {{}}}, {}, {{{{}}}}}
-            Arguments.of(asts[4], 5)
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("getMaxDepthProvider")
-    void test_getMaxDepth(AbstractSyntaxTree array, int expectedResult) {
-        assertEquals(expectedResult, ArrayChecks.getMaxDepth(array));
-    }
-
-    private static Stream<Arguments> getAllArraySizesProvider() {
-        return Stream.of(
-            // {}
-            Arguments.of(asts[0], List.of(List.of(0))),
-            // {5, 10}
-            Arguments.of(asts[1], List.of(List.of(2))),
-            // {{5, 10}}
-            Arguments.of(asts[2], List.of(List.of(1), List.of(2))),
-            // {{{2, 3}, {4}, {}}, {}, {{1}, {2, 3, 4}}}
-            Arguments.of(asts[3], List.of(
-                List.of(3),
-                List.of(3, 0, 2),
-                List.of(2, 1, 0, 1, 3)
-            )),
-            // {{}, {{}, {{}}}, {}, {{{{}}}}}
-            Arguments.of(asts[4], List.of(
-                List.of(4),
-                List.of(0, 2, 0, 1),
-                List.of(0, 1, 1),
-                List.of(0, 1),
-                List.of(0)
-            ))
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("getAllArraySizesProvider")
-    void test_getAllArrayDepths(AbstractSyntaxTree array, List<List<Integer>> expectedResults) {
-        List<List<Integer>> sizes = ArrayChecks.getAllArraySizes(array);
-        assertEquals(expectedResults, sizes);
-    }
-
     private static Stream<Arguments> estimateArraySizesProvider() {
+        AbstractSyntaxTree zero = intToNumberToken(0);
+        AbstractSyntaxTree one = intToNumberToken(1);
+        AbstractSyntaxTree two = intToNumberToken(2);
+        AbstractSyntaxTree three = intToNumberToken(3);
         return Stream.of(
             // {}
-            Arguments.of(asts[0], List.of(0)),
+            Arguments.of(asts[0], List.of(zero)),
             // {5, 10}
-            Arguments.of(asts[1], List.of(2)),
+            Arguments.of(asts[1], List.of(two)),
             // {{5, 10}}
-            Arguments.of(asts[2], List.of(1, 2)),
+            Arguments.of(asts[2], List.of(one, two)),
             // {{{2, 3}, {4}, {}}, {}, {{1}, {2, 3, 4}}}
-            Arguments.of(asts[3], List.of(3, 3, 3)),
+            Arguments.of(asts[3], List.of(three, three, three)),
             // {{}, {{}, {{}}}, {}, {{{{}}}}}
-            Arguments.of(asts[4], List.of(4, 2, 1, 1, 0))
+            Arguments.of(asts[4], List.of(intToNumberToken(4), two, one, one, zero))
         );
     }
 
     @ParameterizedTest
     @MethodSource("estimateArraySizesProvider")
-    void test_estimateArraySizes(AbstractSyntaxTree array, List<Integer> expectedResults) {
-        List<Integer> sizes = ArrayChecks.estimateArraySizes(array);
+    void test_estimateArraySizes(AbstractSyntaxTree array, List<AbstractSyntaxTree> expectedResults) {
+        List<AbstractSyntaxTree> sizes = ArrayChecks.estimateArraySizes(array);
         assertEquals(expectedResults, sizes);
     }
 
-    private static Stream<Arguments> checkArraySizeMatchesExpectationNoErrorProvider() {
-        return Stream.of(
-            // {}
-            Arguments.of(asts[0], List.of(1)),
-            // {5, 10}
-            Arguments.of(asts[1], List.of(4)),
-            // {{5, 10}}
-            Arguments.of(asts[2], List.of(1, 2)),
-            // {{{2, 3}, {4}, {}}, {}, {{1}, {2, 3, 4}}}
-            Arguments.of(asts[3], List.of(3, 3, 3)),
-            // {{}, {{}, {{}}}, {}, {{{{}}}}}
-            Arguments.of(asts[4], List.of(4, 2, 1, 1, 1))
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("checkArraySizeMatchesExpectationNoErrorProvider")
-    void test_checkArraySizeMatchesExpectation_doesNotThrow(AbstractSyntaxTree array, List<Integer> expectedSize) {
-        assertDoesNotThrow(() -> ArrayChecks.checkArraySizeMatchesExpectation(array, expectedSize));
-    }
-
-    private static Stream<Arguments> checkArraySizeMatchesExpectationErrorProvider() {
-        return Stream.of(
-            // {5, 10}
-            Arguments.of(asts[1], List.of(1)),
-            // {{5, 10}}
-            Arguments.of(asts[2], List.of(1, 1)),
-            // {{{2, 3}, {4}, {}}, {}, {{1}, {2, 3, 4}}}
-            Arguments.of(asts[3], List.of(3, 2, 3)),
-            // {{}, {{}, {{}}}, {}, {{{{}}}}}
-            Arguments.of(asts[4], List.of(4, 1, 1, 1, 1))
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("checkArraySizeMatchesExpectationErrorProvider")
-    void test_checkArraySizeMatchesExpectation_throws(AbstractSyntaxTree array, List<Integer> expectedSize) {
-        ArrayBoundsError error = assertThrows(ArrayBoundsError.class, () -> ArrayChecks.checkArraySizeMatchesExpectation(array, expectedSize));
-        assertEquals("Array value size exceeds declared size", error.getMessage());
-    }
-
-    @Test
-    void test_checkArraySizeMatchesExpectation_sizesMismatch() {
-        AbstractSyntaxTree array = asts[2]; // {{5, 10}}
-        List<Integer> expectedSize = List.of(2);
-        ArrayBoundsError error = assertThrows(ArrayBoundsError.class, () -> ArrayChecks.checkArraySizeMatchesExpectation(array, expectedSize));
-        assertEquals("Array value does not match declaration type", error.getMessage());
+    private static AbstractSyntaxTree intToNumberToken(int value) {
+        return new AbstractSyntaxTree(new VariableToken(TokenType.NUMBER, String.valueOf(value)));
     }
 }

--- a/src/test/java/com/piedpiper/swerve/semantic/TestSemanticAnalyzer.java
+++ b/src/test/java/com/piedpiper/swerve/semantic/TestSemanticAnalyzer.java
@@ -650,6 +650,45 @@ public class TestSemanticAnalyzer {
     }
 
     /**
+     * handleArrayDeclaration -> case 3
+     * Source code:
+     *  Array<int> a[3 + 4];
+     */
+    @Test
+    void test_handleArrayDeclarationWithNonConstantSize_mutable_missingValue() {
+        AbstractSyntaxTree source = createASTOfMainBody(new AbstractSyntaxTree("ARRAY-DECL", List.of(
+                new AbstractSyntaxTree(new StaticToken(TokenType.KW_ARR), new StaticToken(TokenType.KW_INT)),
+                new AbstractSyntaxTree(new VariableToken(TokenType.ID, "a")),
+                new AbstractSyntaxTree("ARRAY-INDEX", List.of(
+                    new AbstractSyntaxTree(
+                        new VariableToken(TokenType.OP, "+"),
+                        new VariableToken(TokenType.NUMBER, "3"),
+                        new VariableToken(TokenType.NUMBER, "4")
+                    )
+                ))
+            ))
+        );
+        assertDoesNotThrow(() -> semanticAnalyzer.analyze(source));
+    }
+
+    /**
+     * handleArrayDeclaration -> case 3
+     * Source code:
+     *  Array<int> a["a"];
+     */
+    @Test
+    void test_handleArrayDeclaration_invalidSizeTypeShouldThrowException() {
+        AbstractSyntaxTree source = createASTOfMainBody(new AbstractSyntaxTree("ARRAY-DECL", List.of(
+                new AbstractSyntaxTree(new StaticToken(TokenType.KW_ARR), new StaticToken(TokenType.KW_INT)),
+                new AbstractSyntaxTree(new VariableToken(TokenType.ID, "a")),
+                new AbstractSyntaxTree("ARRAY-INDEX", new VariableToken(TokenType.STRING, "\"a\""))
+            ))
+        );
+        IllegalStatementError error = assertThrows(IllegalStatementError.class, () -> semanticAnalyzer.analyze(source));
+        assertEquals("Array size must be type int but was type STRING", error.getMessage());
+    }
+
+    /**
      * handleArrayDeclaration -> case 4
      * Source code:
      *  Array<int> a[3] = {};


### PR DESCRIPTION
- Make it so that array sizes are no longer checked at compile time
  - trade some safety so that array declarations can be more than just constant numbers
  - will require size/bounds checking to happen at runtime or during code generation
- Change the symbol table to store the array sizes as AST nodes rather than just integer values
  - Will make it easier to retain sizing information
  - more involved to transform into something that can be used later 